### PR TITLE
add user auditing

### DIFF
--- a/casework/__init__.py
+++ b/casework/__init__.py
@@ -2,9 +2,13 @@ import os, logging
 from flask import Flask
 from flask_wtf.csrf import CsrfProtect
 from flask.ext.basicauth import BasicAuth
+from flask.ext.login import LoginManager
 
 app = Flask(__name__)
 app.config.from_object(os.environ.get('SETTINGS'))
+
+login_manager = LoginManager()
+login_manager.init_app(app)
 
 if app.config.get('BASIC_AUTH_USERNAME'):
     app.config['BASIC_AUTH_FORCE'] = True

--- a/casework/server.py
+++ b/casework/server.py
@@ -1,14 +1,23 @@
-from flask import render_template, request, flash, redirect, url_for
+from flask import render_template, request, flash, redirect, url_for, request_started
 from casework import app
 from .mint import Mint
 from forms import RegistrationForm
 import simplejson
 import random
 from healthcheck import HealthCheck
+from flask.ext.login import current_user
 
 mint = Mint(app.config['MINT_URL'])
 HealthCheck(app, '/health')
 
+
+def audit(sender, **extra):
+    if current_user.is_anonymous:
+        sender.logger.debug('Audit: anonymous user requesting %s' % request)
+    else:
+        sender.logger.debug('Audit: user TODO requesting %s' % request)
+
+request_started.connect(audit, app)
 
 def generate_title_number():
     return 'TEST%d' % random.randint(1, 9999)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ wsgiref==0.1.2
 geojson==1.0.7
 uk-postcode-utils==0.1.0
 -e git+https://github.com/Runscope/healthcheck.git@9d661a916f3ab630ae21e014758aa2f21fd40097#egg=healthcheck
+Flask-Login==0.2.11


### PR DESCRIPTION
Rudimentary user auditing, albeit that we're not using `flask.ext.login` for logins, and `BasicAuth` won't populate the `current_user` with the principal. This will be fleshed out once we integrate with other ID providers.
